### PR TITLE
Upgrade ask-sdk from 2.7.0 (2019-08-01) to 2.14.0 (2023-04-01)

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1769,40 +1769,50 @@
       }
     },
     "ask-sdk": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/ask-sdk/-/ask-sdk-2.7.0.tgz",
-      "integrity": "sha512-BMCD810Y7E/DlHmqQ8Ginvobrs69pgEzCWSyCDUhaLnDUIduf+BmqZpxc0zQ/8ABBOjNtzhJ8/mV7USQijk6iw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/ask-sdk/-/ask-sdk-2.14.0.tgz",
+      "integrity": "sha512-EaX1EF59hmtGzuRYybZ9Xyim11PxZwX2T2cYAyBYbv8+v+7gf8gCAmhjXIJV+UA71gIVbtbBEKIFKDhwc+h1rA==",
       "requires": {
-        "ask-sdk-core": "^2.7.0",
-        "ask-sdk-dynamodb-persistence-adapter": "^2.7.0",
-        "ask-sdk-model": "^1.9.0"
+        "ask-sdk-core": "^2.14.0",
+        "ask-sdk-dynamodb-persistence-adapter": "^2.14.0",
+        "ask-sdk-model": "^1.29.0"
+      },
+      "dependencies": {
+        "ask-sdk-dynamodb-persistence-adapter": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/ask-sdk-dynamodb-persistence-adapter/-/ask-sdk-dynamodb-persistence-adapter-2.14.0.tgz",
+          "integrity": "sha512-ZEwZ/ijyzUy+U2/L/L3EtFSBbwg3oLqECW3DtWT5udigFnEAFGEtT7j9iQ3sQw1R2NdIE4R3c4ALH+sngWrZdQ==",
+          "requires": {
+            "aws-sdk": "^2.163.0"
+          }
+        }
       }
     },
     "ask-sdk-core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/ask-sdk-core/-/ask-sdk-core-2.7.0.tgz",
-      "integrity": "sha512-XEuoQOH8B+fQqdVRtEeLWtNL46yjKxwIpbXg042ZaCNYwwmJaVmbvmnR5p0UXgKjULqWm1QEXjYL5INQlfrK7w==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/ask-sdk-core/-/ask-sdk-core-2.14.0.tgz",
+      "integrity": "sha512-G2yEKbY+XYTFzJXGRpsg7xJHqqgBcgnKEgklXUMRWRFv10gwHgtWDLLlBV6h4IdysTx782rCVJK/UcHcaGbEpA==",
       "requires": {
-        "ask-sdk-runtime": "^2.7.0"
+        "ask-sdk-runtime": "^2.14.0"
       }
     },
     "ask-sdk-dynamodb-persistence-adapter": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/ask-sdk-dynamodb-persistence-adapter/-/ask-sdk-dynamodb-persistence-adapter-2.7.0.tgz",
-      "integrity": "sha512-LbwdNLFaUXfy6Wt6Hs4wrZfeopbpZT90SuYT5oo+/g0m8JQNTVVH3Kn4R4K7PTwYFGdHuppvHC1bIu9emt5zZw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/ask-sdk-dynamodb-persistence-adapter/-/ask-sdk-dynamodb-persistence-adapter-2.8.0.tgz",
+      "integrity": "sha512-A5o4nwVV4pr472zMVmW2soywMa6QMrZbf2BAQoMbhi6gsdUeWbFxkuqNNqHYtaq7Ku9lk1wCJc7Kade9VcWkOw==",
       "requires": {
         "aws-sdk": "^2.163.0"
       }
     },
     "ask-sdk-model": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/ask-sdk-model/-/ask-sdk-model-1.19.0.tgz",
-      "integrity": "sha512-AC7wqFvGz2aC0nHU0trPgReqW+4BtQZ+clye0O4ZCYOCRPjM0KEiShCVfToQWMmuyeoZkPCvudPkq3u4ZodQ0w=="
+      "version": "1.69.0",
+      "resolved": "https://registry.npmjs.org/ask-sdk-model/-/ask-sdk-model-1.69.0.tgz",
+      "integrity": "sha512-Hkdfu60udQ3J1IM0EgxWS7CA0lYCvZwHykk/wfziYie/2c8ZfGeryjdDlJD/ik5JbhPOFmI6bgsQzi9k654MeQ=="
     },
     "ask-sdk-runtime": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/ask-sdk-runtime/-/ask-sdk-runtime-2.7.0.tgz",
-      "integrity": "sha512-l2YxzibbTc8Ld5Rpy/Kg3oASiCGKHxgbZnKYrywZStlDPF5tEAGpRBhdtVd+yBSRikl/9fgcetb2wMewtoZF2g=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/ask-sdk-runtime/-/ask-sdk-runtime-2.14.0.tgz",
+      "integrity": "sha512-a96pPs1RU3GgXBHplqAVqh2uxEuSYjTD5+XSbHsf6Fz4KhHpgaxJogOIIybjA6O/d1B9sG+6bjHJGzxBJEcccA=="
     },
     "asn1": {
       "version": "0.2.6",

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "lint": "eslint ./",
     "uploader": "node ./uploader",
-    "mocha": "mocha --require ./tests/_utils/deps.js './tests/**/*.spec.js'",
+    "mocha": "mocha --bail --require ./tests/_utils/deps.js './tests/**/*.spec.js'",
     "start": "firebase serve --only functions:assistant",
     "start:alexa": "bst proxy lambda index-alexa",
     "deploy": "firebase deploy --only functions:assistant",
@@ -19,7 +19,8 @@
   },
   "dependencies": {
     "actions-on-google": "^2.12.0",
-    "ask-sdk": "^2.7.0",
+    "ask-sdk": "2.14.0",
+    "ask-sdk-dynamodb-persistence-adapter": "2.8.0",
     "axios": "^1.3.6",
     "bespoken-tools": "^2.6.7",
     "dashbot": "^11.1.0",


### PR DESCRIPTION
There are some special issues with the upgrade.

If you upgrade just `ask-sdk` to 2.8.0 or any other version, all its dependencies are upgrade to 2.14.0 and unit tests break. You need to set `ask-sdk-dynamodb-persistence-adapter==2.8.0` in packages.json and then upgrade `ask-sdk`. Any newer `ask-sdk-dynamodb-persistence-adapter` version makes the unit tests fail.

I have also tested the app after every update in the Amazon Alexa developer console and it works as expected.