### PR TITLE
Use ask-sdk-dynamodb-persistence-adapter@2.14.0

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1776,16 +1776,6 @@
         "ask-sdk-core": "^2.14.0",
         "ask-sdk-dynamodb-persistence-adapter": "^2.14.0",
         "ask-sdk-model": "^1.29.0"
-      },
-      "dependencies": {
-        "ask-sdk-dynamodb-persistence-adapter": {
-          "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/ask-sdk-dynamodb-persistence-adapter/-/ask-sdk-dynamodb-persistence-adapter-2.14.0.tgz",
-          "integrity": "sha512-ZEwZ/ijyzUy+U2/L/L3EtFSBbwg3oLqECW3DtWT5udigFnEAFGEtT7j9iQ3sQw1R2NdIE4R3c4ALH+sngWrZdQ==",
-          "requires": {
-            "aws-sdk": "^2.163.0"
-          }
-        }
       }
     },
     "ask-sdk-core": {
@@ -1797,9 +1787,9 @@
       }
     },
     "ask-sdk-dynamodb-persistence-adapter": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/ask-sdk-dynamodb-persistence-adapter/-/ask-sdk-dynamodb-persistence-adapter-2.8.0.tgz",
-      "integrity": "sha512-A5o4nwVV4pr472zMVmW2soywMa6QMrZbf2BAQoMbhi6gsdUeWbFxkuqNNqHYtaq7Ku9lk1wCJc7Kade9VcWkOw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/ask-sdk-dynamodb-persistence-adapter/-/ask-sdk-dynamodb-persistence-adapter-2.14.0.tgz",
+      "integrity": "sha512-ZEwZ/ijyzUy+U2/L/L3EtFSBbwg3oLqECW3DtWT5udigFnEAFGEtT7j9iQ3sQw1R2NdIE4R3c4ALH+sngWrZdQ==",
       "requires": {
         "aws-sdk": "^2.163.0"
       }

--- a/functions/package.json
+++ b/functions/package.json
@@ -19,8 +19,7 @@
   },
   "dependencies": {
     "actions-on-google": "^2.12.0",
-    "ask-sdk": "2.14.0",
-    "ask-sdk-dynamodb-persistence-adapter": "2.8.0",
+    "ask-sdk": "^2.14.0",
     "axios": "^1.3.6",
     "bespoken-tools": "^2.6.7",
     "dashbot": "^11.1.0",

--- a/functions/tests/integration/alexa/index.spec.js
+++ b/functions/tests/integration/alexa/index.spec.js
@@ -174,8 +174,8 @@ describe('integration', () => {
 
           // mock attributes persistance
           sandbox = sinon.createSandbox({});
-          sandbox.replace(dynamoDbPersistenceAdapter, 'DynamoDbPersistenceAdapter', DynamoDBMock);
-
+          // Stub the getter property
+          sandbox.stub(dynamoDbPersistenceAdapter, 'DynamoDbPersistenceAdapter').get(() => DynamoDBMock);
           // always choose 1st option
           sandbox.replace(lodash, 'sample', sinon.stub().callsFake(ops => ops[0]));
 


### PR DESCRIPTION
Now use sandbox.stub() to stub the getter property `DynamoDbPersistenceAdapter` of dynamoDbPersistenceAdapter. 
The getter is replaced with a function that returns the DynamoDBMock class.