### PR TITLE
Speak the version properly instead of date format

### DIFF
--- a/functions/src/strings.js
+++ b/functions/src/strings.js
@@ -837,12 +837,12 @@ module.exports = {
 
     version: {
       default: {
-        speech: '<s>Version is <say-as interpret-as="number">{{version}}</say-as>.</s> ' +
+        speech: '<s>Version is <say-as interpret-as="characters">{{version}}</say-as>.</s> ' +
           '<s>{{last.reprompt}}</s>',
       },
 
       playback: {
-        speech: 'Version is <say-as interpret-as="number">{{version}}</say-as>.',
+        speech: 'Version is <say-as interpret-as="characters">{{version}}</say-as>.',
       }
     },
 


### PR DESCRIPTION
Currently if you ask the app the version, it is saying in a date format.
Fixed this issue